### PR TITLE
Add MCP server entrypoint for repo map generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,42 @@ Options include:
 
 Run `repomap-tool --help` to see the complete list.
 
+## MCP server integration
+
+The toolkit also exposes a [Model Context Protocol](https://github.com/modelcontextprotocol) server so
+you can invoke repo map generation directly from MCP-compatible clients such as OpenAI Studio.
+
+### Install with `uv`
+
+```bash
+# Install the package (and the MCP entrypoint) from this repository
+uv tool install --python 3.12 ./repomap_tool
+
+# Run the MCP server on stdio
+repomap-mcp --transport stdio
+```
+
+### Example `mcpservers.json`
+
+Add the server to your MCP configuration so Studio can launch it automatically. A minimal
+`mcpservers.json` entry looks like this:
+
+```json
+{
+  "servers": [
+    {
+      "name": "repomap",
+      "command": "repomap-mcp",
+      "args": [],
+      "transport": { "type": "stdio" }
+    }
+  ]
+}
+```
+
+Once registered, the `generate_repo_map` tool returns the exact same context blocks that power aider,
+and the `generate_ranked_tags` tool provides structured access to the ranked identifiers.
+
 ## Sample outputs
 
 The snippets below showcase what the CLI produces when it analyzes this repository. Each

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pygments>=2.16",
     "tqdm>=4.64",
     "tree-sitter-languages>=1.10.2",
+    "mcp>=1.16",
 ]
 
 [project.urls]
@@ -22,6 +23,7 @@ Homepage = "https://github.com/unixsysdev/repomap.git"
 
 [project.scripts]
 repomap-tool = "repomap_tool.cli:main"
+repomap-mcp = "repomap_tool.mcp.server:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/repomap_tool/mcp/__init__.py
+++ b/repomap_tool/mcp/__init__.py
@@ -1,0 +1,11 @@
+"""Model Context Protocol integration for :mod:`repomap_tool`."""
+
+from .server import RankedTag, app, create_server, main
+
+__all__ = [
+    "RankedTag",
+    "app",
+    "create_server",
+    "main",
+]
+

--- a/repomap_tool/mcp/server.py
+++ b/repomap_tool/mcp/server.py
@@ -1,0 +1,272 @@
+"""Expose :mod:`repomap_tool` as an MCP server."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Literal, Sequence
+
+import anyio
+from mcp.server.fastmcp import Context, FastMCP
+from pydantic import BaseModel, Field
+
+from ..service import RepoMapBuilder
+
+RefreshMode = Literal["auto", "always", "files", "manual"]
+
+
+class RankedTag(BaseModel):
+    """Structured representation of a ranked tag entry."""
+
+    file: str = Field(description="Repository-relative path to the symbol's file.")
+    absolute_file: str = Field(description="Absolute path to the symbol's file.")
+    line: int = Field(description="Line number where the symbol occurs.")
+    name: str = Field(description="Identifier that was ranked.")
+    kind: str = Field(description="Symbol type emitted by the repo map engine.")
+
+
+def _resolve_root(root: str | None) -> Path:
+    candidate = Path(root).expanduser() if root else Path.cwd()
+    try:
+        resolved = candidate.resolve()
+    except FileNotFoundError as exc:  # pragma: no cover - mirrors pathlib behaviour
+        raise ValueError(f"Repository root does not exist: {candidate}") from exc
+
+    if not resolved.exists():
+        raise ValueError(f"Repository root does not exist: {resolved}")
+    if not resolved.is_dir():
+        raise ValueError(f"Repository root must be a directory: {resolved}")
+    return resolved
+
+
+def _normalise_refresh(value: str | None) -> RefreshMode:
+    if value is None:
+        return "auto"
+
+    valid_modes: tuple[RefreshMode, ...] = ("auto", "always", "files", "manual")
+    if value not in valid_modes:
+        raise ValueError(f"Invalid refresh mode: {value}")
+    return value  # type: ignore[return-value]
+
+
+def _gather_context(
+    inline_context: str | None,
+    context_files: Sequence[str] | None,
+    root: Path,
+    ctx: Context | None,
+) -> str | None:
+    segments: list[str] = []
+
+    if inline_context:
+        segments.append(inline_context)
+
+    for fname in context_files or []:
+        file_path = Path(fname)
+        if not file_path.is_absolute():
+            file_path = (root / file_path).resolve()
+        else:
+            file_path = file_path.resolve()
+
+        try:
+            segments.append(file_path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            message = f"Unable to read context file {file_path}: {exc}"
+            if ctx is not None:
+                ctx.warning(message)
+                continue
+            raise ValueError(message) from exc
+
+    combined = "\n".join(segment for segment in segments if segment)
+    return combined or None
+
+
+def _create_builder(
+    root: Path,
+    map_tokens: int | None,
+    refresh: RefreshMode,
+    verbose: bool,
+    model_name: str | None,
+) -> RepoMapBuilder:
+    return RepoMapBuilder(
+        root=root,
+        map_tokens=map_tokens,
+        refresh=refresh,
+        verbose=verbose,
+        model_name=model_name,
+    )
+
+
+def generate_repo_map_tool(
+    *,
+    root: str | None = None,
+    chat_files: Sequence[str] | None = None,
+    context: str | None = None,
+    context_files: Sequence[str] | None = None,
+    mentioned_files: Sequence[str] | None = None,
+    mentioned_identifiers: Sequence[str] | None = None,
+    include_files: Sequence[str] | None = None,
+    map_tokens: int | None = None,
+    refresh: str | None = None,
+    force_refresh: bool = False,
+    model_name: str | None = None,
+    verbose: bool = False,
+    ctx: Context | None = None,
+) -> str:
+    """Generate a repository map identical to the aider workflow."""
+
+    root_path = _resolve_root(root)
+    builder = _create_builder(root_path, map_tokens, _normalise_refresh(refresh), verbose, model_name)
+    gathered_context = _gather_context(context, context_files, root_path, ctx)
+
+    repo_map = builder.generate_map(
+        chat_files=list(chat_files or []),
+        context=gathered_context,
+        mentioned_fnames=list(mentioned_files or []),
+        mentioned_identifiers=list(mentioned_identifiers or []),
+        force_refresh=force_refresh,
+        include_files=list(include_files or []),
+    )
+
+    if not repo_map:
+        raise ValueError("No repository map could be generated for the requested repository.")
+
+    return repo_map
+
+
+def generate_ranked_tags_tool(
+    *,
+    root: str | None = None,
+    chat_files: Sequence[str] | None = None,
+    context: str | None = None,
+    context_files: Sequence[str] | None = None,
+    mentioned_files: Sequence[str] | None = None,
+    mentioned_identifiers: Sequence[str] | None = None,
+    include_files: Sequence[str] | None = None,
+    map_tokens: int | None = None,
+    refresh: str | None = None,
+    model_name: str | None = None,
+    verbose: bool = False,
+    limit: int | None = None,
+    ctx: Context | None = None,
+) -> list[RankedTag]:
+    """Return the ranked tags that power the repo map."""
+
+    if limit is not None and limit < 0:
+        raise ValueError("limit must be greater than or equal to zero")
+
+    root_path = _resolve_root(root)
+    builder = _create_builder(root_path, map_tokens, _normalise_refresh(refresh), verbose, model_name)
+    gathered_context = _gather_context(context, context_files, root_path, ctx)
+
+    tags = builder.generate_ranked_tags(
+        chat_files=list(chat_files or []),
+        context=gathered_context,
+        mentioned_fnames=list(mentioned_files or []),
+        mentioned_identifiers=list(mentioned_identifiers or []),
+        include_files=list(include_files or []),
+    )
+
+    if limit is not None:
+        tags = tags[:limit]
+
+    return [
+        RankedTag(
+            file=tag.rel_fname,
+            absolute_file=tag.fname,
+            line=tag.line,
+            name=tag.name,
+            kind=tag.kind,
+        )
+        for tag in tags
+    ]
+
+
+def register_tools(server: FastMCP) -> FastMCP:
+    """Attach repo map tools to *server* and return it."""
+
+    server.tool(
+        name="generate_repo_map",
+        description="Build a condensed repository map for the supplied project.",
+    )(generate_repo_map_tool)
+
+    server.tool(
+        name="generate_ranked_tags",
+        description="Return the ranked identifiers used to construct the repository map.",
+        structured_output=True,
+    )(generate_ranked_tags_tool)
+
+    return server
+
+
+def create_server(**kwargs) -> FastMCP:
+    """Create a :class:`FastMCP` server with the repo map tools registered."""
+
+    server = FastMCP(
+        name="repomap-tool",
+        instructions=(
+            "Generate repository maps and ranked tags using repomap-tool. "
+            "Pass chat files, inline context, or explicit mentions to focus the output."
+        ),
+        website_url="https://github.com/unixsysdev/repomap",
+        **kwargs,
+    )
+    return register_tools(server)
+
+
+app = create_server()
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Expose repomap-tool as a Model Context Protocol server.",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "sse", "http"],
+        default="stdio",
+        help="Transport mechanism to use when serving the MCP tools.",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="Host interface for SSE or HTTP transports (defaults to 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Port number for SSE or HTTP transports (defaults to 8000).",
+    )
+    parser.add_argument(
+        "--mount-path",
+        default=None,
+        help="Optional mount path for the SSE transport (defaults to the configured mount path).",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    server_kwargs = {}
+    if args.host is not None:
+        server_kwargs["host"] = args.host
+    if args.port is not None:
+        server_kwargs["port"] = args.port
+
+    server = create_server(**server_kwargs)
+
+    if args.transport == "stdio":
+        anyio.run(server.run_stdio_async)
+    elif args.transport == "sse":
+        anyio.run(server.run_sse_async, args.mount_path)
+    else:
+        anyio.run(server.run_streamable_http_async)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+

--- a/tests/basic/test_mcp_server.py
+++ b/tests/basic/test_mcp_server.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import git
+
+from repomap_tool.mcp.server import (
+    create_server,
+    generate_ranked_tags_tool,
+    generate_repo_map_tool,
+)
+
+
+def _seed_repository(path: Path) -> None:
+    repo = git.Repo.init(path)
+    file_a = path / "alpha.py"
+    file_b = path / "beta.py"
+    file_a.write_text(
+        """
+import beta
+
+
+def alpha():
+    return beta.beta()
+"""
+    )
+    file_b.write_text(
+        """
+def beta():
+    return 42
+"""
+    )
+    repo.index.add(["alpha.py", "beta.py"])
+    repo.index.commit("initial commit")
+
+
+def test_generate_repo_map_tool(tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _seed_repository(repo_root)
+
+    result = generate_repo_map_tool(root=str(repo_root))
+
+    assert "alpha.py" in result
+    assert "beta.py" in result
+
+
+def test_generate_ranked_tags_tool(tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _seed_repository(repo_root)
+
+    tags = generate_ranked_tags_tool(root=str(repo_root), limit=2)
+
+    assert len(tags) <= 2
+    assert tags, "Expected ranked tags to be returned"
+    first = tags[0]
+    assert first.file.endswith(".py")
+    assert isinstance(first.line, int)
+    assert first.name
+
+
+def test_create_server_registers_tools():
+    server = create_server()
+    tool_names = {tool.name for tool in server._tool_manager.list_tools()}
+
+    assert {"generate_repo_map", "generate_ranked_tags"}.issubset(tool_names)
+


### PR DESCRIPTION
## Summary
- add a FastMCP server that wraps repomap-tool functionality for repo maps and ranked tags
- document uv-based installation and configuration for the new MCP entrypoint
- cover the MCP server helpers and registration logic with unit tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68e231b101d88323adfb4e75c564ff45