### PR TITLE
Fix MCP server packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "diskcache>=5.6",
     "GitPython>=3.1",
     "grep-ast>=0.4",
+    "anyio>=4.4",
     "networkx<3.5",
     "scipy<1.16",
     "pygments>=2.16",
@@ -29,7 +30,10 @@ repomap-mcp = "repomap_tool.mcp.server:main"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["repomap_tool"]
+include = [
+    "repomap_tool",
+    "repomap_tool.*",
+]
 
 [build-system]
 requires = ["setuptools>=68"]


### PR DESCRIPTION
## Summary
- include the MCP server subpackage when building distributions
- declare the MCP server's anyio runtime dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e23cf734ac832384831b855bc0540e