### PR TITLE
Improve MCP server defaults for stdio clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "diskcache>=5.6",
     "GitPython>=3.1",
     "grep-ast>=0.4",
+    "anyio>=4.4",
     "networkx<3.5",
     "scipy<1.16",
     "pygments>=2.16",
@@ -29,7 +30,10 @@ repomap-mcp = "repomap_tool.mcp.server:main"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["repomap_tool"]
+include = [
+    "repomap_tool",
+    "repomap_tool.*",
+]
 
 [build-system]
 requires = ["setuptools>=68"]

--- a/tests/basic/test_mcp_server.py
+++ b/tests/basic/test_mcp_server.py
@@ -66,3 +66,18 @@ def test_create_server_registers_tools():
 
     assert {"generate_repo_map", "generate_ranked_tags"}.issubset(tool_names)
 
+
+def test_generate_repo_map_tool_uses_default_root(tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _seed_repository(repo_root)
+
+    try:
+        create_server(default_root=repo_root)
+        result = generate_repo_map_tool()
+    finally:
+        create_server(default_root=None)
+
+    assert "alpha.py" in result
+    assert "beta.py" in result
+


### PR DESCRIPTION
## Summary
- add a reusable default repository root for MCP tool invocations
- surface a `--root` option and startup messaging in the MCP CLI
- cover the default root behaviour with a regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e23cf734ac832384831b855bc0540e