### PR TITLE
Improve MCP CLI logging controls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "diskcache>=5.6",
     "GitPython>=3.1",
     "grep-ast>=0.4",
+    "anyio>=4.4",
     "networkx<3.5",
     "scipy<1.16",
     "pygments>=2.16",
@@ -29,7 +30,10 @@ repomap-mcp = "repomap_tool.mcp.server:main"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["repomap_tool"]
+include = [
+    "repomap_tool",
+    "repomap_tool.*",
+]
 
 [build-system]
 requires = ["setuptools>=68"]


### PR DESCRIPTION
## Summary
- add a reusable default repository root for MCP tool invocations
- surface a `--root` option and startup messaging in the MCP CLI
- cover the default root behaviour with a regression test
- add logging controls and graceful interrupt handling to the MCP CLI for stdio clients
- add regression coverage for log level parsing and keyboard interrupt handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e23cf734ac832384831b855bc0540e